### PR TITLE
can't convert Pathname to String (TypeError) - ruby gem 1.7

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -67,7 +67,6 @@ module HTTMultiParty
    end
 end
 
-dir = Pathname(__FILE__).dirname.expand_path
-require dir + 'httmultiparty/multipartable'
-require dir + 'httmultiparty/multipart_post'
-require dir + 'httmultiparty/multipart_put'
+require 'httmultiparty/multipartable'
+require 'httmultiparty/multipart_post'
+require 'httmultiparty/multipart_put'


### PR DESCRIPTION
/home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:1090:in escape': can't convert Pathname to String (TypeError)
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:1090:inblock in loaded_path?'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:1089:in each'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:1089:infind'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:1089:in loaded_path?'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:inrequire'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/dependencies.rb:239:in block in require'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/dependencies.rb:225:inblock in load_dependency'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/dependencies.rb:596:in new_constants_in'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/dependencies.rb:225:inload_dependency'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/dependencies.rb:239:in require'
from /home/ananth/.rvm/gems/ruby-1.9.2-p180/gems/httmultiparty-0.3/lib/httmultiparty.rb:71:in'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:57:in require'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:57:inrescue in require'
from /home/ananth/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
