### PR TITLE
Allow uploading UploadIOs for greater flexibility

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -62,7 +62,7 @@ module HTTMultiParty
 
     private
       def query_contains_files?(query)
-        query.is_a?(Hash) && query.select { |k,v| v.is_a?(Hash) ? query_contains_files?(v) : v.is_a?(File) }.length > 0
+        query.is_a?(Hash) && query.select { |k,v| v.is_a?(Hash) ? query_contains_files?(v) : (v.is_a?(File) || v.is_a?(UploadIO)) }.length > 0
       end
    end
 end


### PR DESCRIPTION
This allows taking any IO stream and uploading it via httmultiparty, 
provided you take the effort to wrap things in UploadIO yourself.

There seems to be no special reason for restricting things to only Files (there seems to be no specific reason not to allow generic IO streams, except they may miss a path name)
