### PR TITLE
Fix QUERY_STRING_NORMALIZER when there are non File params

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -10,8 +10,9 @@ module HTTMultiParty
   QUERY_STRING_NORMALIZER = Proc.new do |params|
     multipart = false
     result = HTTMultiParty.flatten_params(params).map do |(k,v)|
-      multipart ||= TRANSFORMABLE_TYPES.include?(v.class)
-      [k, multipart ? HTTMultiParty.file_to_upload_io(v) : v]
+      is_file = TRANSFORMABLE_TYPES.include?(v.class)
+      multipart ||= is_file
+      [k, is_file ? HTTMultiParty.file_to_upload_io(v) : v]
     end
 
     multipart ? result : HTTParty::Request::NON_RAILS_QUERY_STRING_NORMALIZER.call(params)

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -139,5 +139,14 @@ describe HTTMultiParty do
         :file => [somefile, sometempfile]
       }).each { |(k,v)| v.should be_an UploadIO }
     end
+
+    it "should map a file and a string" do
+      (key, value) = subject.call({
+        :file => sometempfile,
+        :some_string => 'some string'
+      }).last
+
+      value.should be_a String
+    end
   end
 end


### PR DESCRIPTION
When a non File param is after a File param it tried to handle it as a File.
