### PR TITLE
Fixed bug in body= to support digest_auth option.

### DIFF
--- a/lib/httmultiparty/multipartable.rb
+++ b/lib/httmultiparty/multipartable.rb
@@ -7,8 +7,13 @@ module HTTMultiParty::Multipartable
   end
 
   def body=(value)
-    @body_parts = value.map {|(k,v)| Parts::Part.new(boundary, k, v)}
-    @body_parts << Parts::EpiloguePart.new(boundary)
+    if value == ''
+      super
+    else
+      @body_parts = value.map {|(k,v)| Parts::Part.new(boundary, k, v)}
+      @body_parts << Parts::EpiloguePart.new(boundary)
+    end
+
     set_headers_for_body
   end
 

--- a/spec/httmultiparty/multipartable_spec.rb
+++ b/spec/httmultiparty/multipartable_spec.rb
@@ -28,4 +28,13 @@ describe HTTMultiParty::Multipartable do
       it { should_not include("a") }
     end
   end
+
+  # in the case of http digest authentication, body= is called with empty string for the first request
+  it "should not raise an error with an empty-string body" do
+    lambda {
+      request = request_class.new("/path")
+      request.body = ''
+    }.should_not raise_error
+  end
+
 end


### PR DESCRIPTION
Was raising an error when digest_auth option was used.  The error was caused by to the two-request nature of digest authentication, in which the first request has an empty body.

Also added a spec.
