### PR TITLE
Add MIT license to gemspec

### DIFF
--- a/httmultiparty.gemspec
+++ b/httmultiparty.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/jwagener/httmultiparty"
   s.summary     = "HTTMultiParty is a thin wrapper around HTTParty to provide multipart uploads."
   s.description = "HTTMultiParty is a thin wrapper around HTTParty to provide multipart uploads."
- 
+  s.license     = 'MIT'
+
   s.required_rubygems_version = ">= 1.3.6"
   
   s.add_dependency 'httparty', ">= 0.7.3"


### PR DESCRIPTION
Makes tools like https://github.com/pivotal/LicenseFinder happy.
