### PR TITLE
force value given to HTTMultiParty::Multipartable#body= to be an array

### DIFF
--- a/lib/httmultiparty/multipartable.rb
+++ b/lib/httmultiparty/multipartable.rb
@@ -7,7 +7,7 @@ module HTTMultiParty::Multipartable
   end
 
   def body=(value)
-    @body_parts = value.map {|(k,v)| Parts::Part.new(boundary, k, v)}
+    @body_parts = Array(value).map {|(k,v)| Parts::Part.new(boundary, k, v)}
     @body_parts << Parts::EpiloguePart.new(boundary)
     set_headers_for_body
   end


### PR DESCRIPTION
I am using your gem to upload files to Filepicker and I get an `undefined method map for string` error on some requests. This fixes it. 
