### PR TITLE
Add ActionDispatch::Http::UploadedFile class as transformable

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -5,7 +5,7 @@ require 'httparty'
 require 'net/http/post/multipart'
 
 module HTTMultiParty
-  TRANSFORMABLE_TYPES = [File, Tempfile]
+  TRANSFORMABLE_TYPES = [File, Tempfile, ActionDispatch::Http::UploadedFile]
 
   QUERY_STRING_NORMALIZER = Proc.new do |params|
     HTTMultiParty.flatten_params(params).map do |(k,v)|


### PR DESCRIPTION
Adding ActionDispatch::Http::UploadedFile as Transformable-Type we can use a Rails uploaded file directly in HttMultiParty.

Use case would be store in a remote server a uploaded file in a Rails application. In my application attach a user uploaded file into Jira using the REST API.
