### PR TITLE
Trying to make TRANSFORMABLE_TYPES generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ response = SomeClient.post('/', :query => {
   :somefile => File.new('README.md')
 }, :detect_mime_type => true)
 ```
+## File class support
+
+You can use any class that responds to a `read` method. This method should act similar to the `IO#read` method. To set the filename your file class can optionally respond to the `original_filename` method, which should return a `String`.

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -6,8 +6,6 @@ require 'net/http/post/multipart'
 require 'mimemagic'
 
 module HTTMultiParty
-  TRANSFORMABLE_TYPES = [File, Tempfile]
-
   def self.included(base)
     base.send :include, HTTParty
     base.extend ClassMethods
@@ -28,7 +26,7 @@ module HTTMultiParty
     Proc.new do |params|
       HTTMultiParty.flatten_params(params).map do |(k,v)|
         if file_present_in_params?(params)
-          [k, TRANSFORMABLE_TYPES.include?(v.class) ? HTTMultiParty.file_to_upload_io(v, detect_mime_type) : v]
+          [k, v.respond_to?(:read) ? HTTMultiParty.file_to_upload_io(v, detect_mime_type) : v]
         else
           "#{k}=#{v}"
         end
@@ -93,7 +91,7 @@ module HTTMultiParty
   end
 
   def self.file_present?(value)
-    TRANSFORMABLE_TYPES.include?(value.class) || value.is_a?(UploadIO)
+    value.respond_to?(:read)
   end
 
    module ClassMethods

--- a/spec/fixtures/custom_test_file.rb
+++ b/spec/fixtures/custom_test_file.rb
@@ -1,0 +1,1 @@
+class CustomTestFile < File; end

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -9,6 +9,7 @@ describe HTTMultiParty do
   let(:somejpegfile) { File.new(File.join(File.dirname(__FILE__), 'fixtures/somejpegfile.jpeg')) }
   let(:somepngfile) { File.new(File.join(File.dirname(__FILE__), 'fixtures/somepngfile.png')) }
   let(:sometempfile) { Tempfile.new('sometempfile') }
+  let(:customtestfile) { CustomTestFile.new(File.join(File.dirname(__FILE__), 'fixtures/somefile.txt')) }
   let(:someuploadio) { UploadIO.new(somefile, "application/octet-stream") }
   let(:klass) { Class.new.tap { |k| k.instance_eval { include HTTMultiParty} } }
 
@@ -165,6 +166,14 @@ describe HTTMultiParty do
     it "should map a Tempfile to UploadIO" do
       (first_k, first_v) = subject.call({
         :file => sometempfile
+      }).first
+
+      first_v.should be_an UploadIO
+    end
+
+    it "should map a CustomTestfile to UploadIO" do
+      (first_k, first_v) = subject.call({
+        :file => customtestfile
       }).first
 
       first_v.should be_an UploadIO

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require File.join(File.dirname(__FILE__), '..', 'lib', 'httmultiparty')
+require File.join(File.dirname(__FILE__), 'fixtures', 'custom_test_file')
 require 'fakeweb'
 
 def file_fixture(filename)


### PR DESCRIPTION
Trying to get ActionDispatch::Http::UploadedFile objects to work with HTTMultiParty.

This is related to this pull request: https://github.com/jwagener/httmultiparty/pull/27

I don't think this is ready to merge right this moment, but I hope to get some feedback on how this could be made to work and be accepted.

Thanks!
