### PR TITLE
If an UploadIO is passed as a parameter we should use it

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -26,7 +26,7 @@ module HTTMultiParty
     Proc.new do |params|
       HTTMultiParty.flatten_params(params).map do |(k,v)|
         if file_present_in_params?(params)
-          [k, v.respond_to?(:read) ? HTTMultiParty.file_to_upload_io(v, detect_mime_type) : v]
+          [k, v.respond_to?(:read) && !v.is_a?(UploadIO) ? HTTMultiParty.file_to_upload_io(v, detect_mime_type) : v]
         else
           "#{k}=#{v}"
         end

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -163,6 +163,14 @@ describe HTTMultiParty do
       first_v.should be_an UploadIO
     end
 
+    it "should use the same UploadIO" do
+      (first_k, first_v) = subject.call({
+        :file => someuploadio
+      }).first
+
+      first_v.should eq(someuploadio)
+    end
+
     it "should map a Tempfile to UploadIO" do
       (first_k, first_v) = subject.call({
         :file => sometempfile


### PR DESCRIPTION
The passed in UploadIO can contain a mimetype and we don't want
to lose it.
