### PR TITLE
Remove unnecessary gem statements

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -1,5 +1,3 @@
-gem 'httparty'
-gem 'multipart-post'
 require 'tempfile'
 require 'httparty'
 require 'net/http/post/multipart'


### PR DESCRIPTION
The gem statements for httparty and multipart-post should not be necessary and removing them fixes an issue using the httmultiparty gem with bundle install --standalone.
