### PR TITLE
Fix a bug where files in nested parameter hashes wouldn't be converted to instances of UploadIO

### DIFF
--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -83,7 +83,7 @@ module HTTMultiParty
       if v.is_a? Array
         v.any? { |vv| file_present?(vv) }
       elsif v.is_a? Hash
-        v.values.any? { |vv| file_present?(vv) }
+        file_present_in_params?(v)
       else
         file_present?(v)
       end

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -185,6 +185,14 @@ describe HTTMultiParty do
       }).each { |(k,v)| v.should be_an UploadIO }
     end
 
+    it "should map files in nested hashes to UploadIOs" do
+      (first_k, first_v) = subject.call({
+        :foo => { :bar => { :baz => somefile } }
+      }).first
+
+      first_v.should be_an UploadIO
+    end
+
     it 'parses file and non-file parameters properly irrespective of their position' do
       response = subject.call(
         :name  => 'foo',


### PR DESCRIPTION
This PR fixes a bug where files in nested hashes wouldn't be uploaded, and instead you'd get something like this in the HTTP body:

```
-------------RubyMultipartPost
Content-Disposition: form-data; name="upload_file[data][file]=#<File:0x007f95d1a7e798>"
```

My use case:

``` ruby
MyAPI.create({
  subject: 'Passport Image',
  upload_file: {
    data: {
      file: File.open('/Users/daniel/Desktop/bart-simpson.jpg'),
      file_name: 'bart.jpg'
    }
  }
})
```

Have at it! :sparkling_heart:
