### PR TITLE
Replace mimemagic with marcel gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,34 +3,37 @@ PATH
   specs:
     httmultiparty (0.3.16)
       httparty (>= 0.7.3)
-      mimemagic
+      marcel
       multipart-post
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
+    diff-lcs (1.4.4)
     fakeweb (1.3.0)
-    httparty (0.13.3)
-      json (~> 1.8)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (1.8.1)
-    mimemagic (0.2.1)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
-    rake (10.4.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    marcel (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
   ruby
@@ -40,3 +43,6 @@ DEPENDENCIES
   httmultiparty!
   rake
   rspec
+
+BUNDLED WITH
+   2.2.3

--- a/httmultiparty.gemspec
+++ b/httmultiparty.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty', '>= 0.7.3'
   s.add_dependency 'multipart-post'
-  s.add_dependency 'mimemagic'
+  s.add_dependency 'marcel'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 require 'httparty'
 require 'net/http/post/multipart'
-require 'mimemagic'
+require 'marcel'
 
 module HTTMultiParty
   def self.included(base)
@@ -15,7 +15,7 @@ module HTTMultiParty
     else
       filename =  File.split(file.path).last
     end
-    content_type = detect_mime_type ? MimeMagic.by_path(filename) : 'application/octet-stream'
+    content_type = detect_mime_type ? Marcel::Magic.by_path(filename) : 'application/octet-stream'
     UploadIO.new(file, content_type, filename)
   end
 


### PR DESCRIPTION
I know this library is unmaintained but just in case somebody else needs it.

Update dependency on mimemagic to allow non-GPL usage of Httmultiparty